### PR TITLE
feat(ocp-home): upgrade external-dns from v1.13.0 to v1.19.0

### DIFF
--- a/kubernetes/ocp-home/system/external-dns/kustomization.yaml
+++ b/kubernetes/ocp-home/system/external-dns/kustomization.yaml
@@ -24,7 +24,8 @@ helmCharts:
     policy: upsert-only
     sources:
       - ingress
-    provider: cloudflare
+    provider:
+      name: cloudflare
     registry: noop
     extraArgs:
       annotation-filter: "external-dns.alpha.kubernetes.io/include in (true)"


### PR DESCRIPTION
## Summary
Upgrades external-dns Helm chart from v1.13.0 to v1.19.0 (external-dns image from v0.13.5 to v0.19.0).

## Changes
- Upgraded Helm chart version from 1.13.0 to 1.19.0
- Updated values format for v1.19.0 schema changes:
  - `extraArgs`: Changed from array to object format
  - `provider`: Changed from string to object format with `name` field

## Testing
- ✅ Kustomize build successful
- ✅ Server-side dry-run validation passed
- ✅ ArgoCD sync successful (Synced and Healthy)
- ✅ Deployment running external-dns v0.19.0
- ✅ All args rendering correctly

## Related
Tested on feature branch `test-external-dns-upgrade` and verified working in cluster.