### PR TITLE
fix(devcontainer): upgrade base image to Ubuntu 24.04

### DIFF
--- a/containers/devcontainer/Containerfile
+++ b/containers/devcontainer/Containerfile
@@ -32,7 +32,7 @@ RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
 
 # Install Python packages
 COPY requirements.txt /tmp/requirements.txt
-RUN pip3 install -r /tmp/requirements.txt
+RUN pip3 install --break-system-packages -r /tmp/requirements.txt
 
 # Install `oc` and `kubectl`
 ENV OC_VERSION=4.17.0-okd-scos.0


### PR DESCRIPTION
## Summary
- Upgrade devcontainer base image from Ubuntu 22.04 to 24.04
- Updates image registry path from `vscode/devcontainers` to `devcontainers`
- Provides Python 3.12, which is required by ansible-core 2.20.x

## Context
This fixes the container build failure in PR #79 where `ansible-core==2.20.1` could not be installed because:
- Ubuntu 22.04 ships with Python 3.10
- ansible-core 2.20 dropped support for Python 3.11 and below, requiring Python 3.12+

## Test plan
- [x] Verify container build succeeds with the new base image
- [ ] Merge PR #79 after this is merged to trigger a combined build