### PR TITLE
fix(hf-cli): pin huggingface_hub version and update to hf command

### DIFF
--- a/containers/hf-cli/Containerfile
+++ b/containers/hf-cli/Containerfile
@@ -25,4 +25,4 @@ ENV HF_HOME=/model-files-cache
 
 USER 1001
 
-CMD ["huggingface-cli"]
+CMD ["hf"]

--- a/containers/hf-cli/README.md
+++ b/containers/hf-cli/README.md
@@ -4,7 +4,7 @@ A container image with the Hugging Face CLI pre-installed for model downloading.
 
 ## Purpose
 
-This image provides the `huggingface-cli` command for downloading models from Hugging Face Hub. Using a pre-built image with the CLI installed enables container layer caching, avoiding pip installs at runtime.
+This image provides the `hf` command for downloading models from Hugging Face Hub. Using a pre-built image with the CLI installed enables container layer caching, avoiding pip installs at runtime.
 
 ## Build
 
@@ -18,14 +18,14 @@ Download a model:
 
 ```bash
 podman run --rm -v ./models:/models:Z hf-cli:latest \
-    huggingface-cli download <model-repo> --local-dir=/models/<model-name>
+    hf download <model-repo> --local-dir=/models/<model-name>
 ```
 
 Example:
 
 ```bash
 podman run --rm -v ./models:/models:Z hf-cli:latest \
-    huggingface-cli download RedHatAI/Qwen3-30B --local-dir=/models/Qwen3-30B
+    hf download RedHatAI/Qwen3-30B --local-dir=/models/Qwen3-30B
 ```
 
 ## OpenShift Compatibility

--- a/containers/hf-cli/requirements.txt
+++ b/containers/hf-cli/requirements.txt
@@ -1,1 +1,1 @@
-huggingface_hub[cli]
+huggingface_hub==1.1.6


### PR DESCRIPTION
## Summary
- Pin `huggingface_hub==1.1.6` for better Renovate tracking
- Remove deprecated `[cli]` extra (CLI is now built-in as of v1.0)
- Update Containerfile CMD from `huggingface-cli` to `hf`
- Update README examples to use `hf` command

## Context
The `[cli]` extra was removed in huggingface_hub v1.0 as the CLI is now included by default. The `huggingface-cli` command was replaced by `hf`. The actual usage in `download-model.sh` already uses the `hf` command.