### PR TITLE
chore: consolidate extensions into extensions.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,22 +6,6 @@
 		"--cap-add=NET_RAW",
 		"--network=host"
 	],
-	"customizations": {
-	  "vscode": {
-		"extensions": [
-			"hashicorp.terraform",
-			"ms-azuretools.vscode-docker",
-			"ms-vscode-remote.remote-containers",
-			"ms-vscode-remote.remote-ssh",
-			"ms-vscode-remote.remote-ssh-edit",
-			"redhat.ansible",
-			"yzhang.markdown-all-in-one",
-			"ms-kubernetes-tools.vscode-kubernetes-tools",
-			"GitHub.vscode-pull-request-github",
-			"Anthropic.claude-code"
-		]
-	  }
-	},
 	"remoteUser": "morey-tech",
 	"postCreateCommand": "/workspaces/homelab/.devcontainer/postCreate.sh"
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,14 @@
 {
   "recommendations": [
     "Anthropic.claude-code",
-    "redhat.ansible"
+    "GitHub.vscode-pull-request-github",
+    "hashicorp.terraform",
+    "ms-azuretools.vscode-docker",
+    "ms-kubernetes-tools.vscode-kubernetes-tools",
+    "ms-vscode-remote.remote-containers",
+    "ms-vscode-remote.remote-ssh",
+    "ms-vscode-remote.remote-ssh-edit",
+    "redhat.ansible",
+    "yzhang.markdown-all-in-one"
   ]
 }


### PR DESCRIPTION
## Summary
- Migrate all extension recommendations from `.devcontainer/devcontainer.json` to `.vscode/extensions.json`
- Remove `customizations.vscode.extensions` from devcontainer.json

This makes `.vscode/extensions.json` the single source of truth for recommended extensions, working for both VS Code devcontainers and OpenShift DevSpaces.

## Changes
| File | Change |
|------|--------|
| `.vscode/extensions.json` | Added 8 extensions (10 total) |
| `.devcontainer/devcontainer.json` | Removed `customizations` block |

Closes #116