### PR TITLE
feat(containers): add GitHub CLI auto-authentication to devspace-base

### DIFF
--- a/containers/devspace-base/Containerfile
+++ b/containers/devspace-base/Containerfile
@@ -24,6 +24,17 @@ RUN ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
 # The install script auto-detects architecture and installs to /home/user/.local/bin/
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
+# Install GitHub CLI auto-authentication script
+COPY gh-auth-init.sh /usr/local/bin/gh-auth-init.sh
+RUN chmod +x /usr/local/bin/gh-auth-init.sh && \
+    mkdir -p /home/user/.bashrc.d && \
+    ln -s /usr/local/bin/gh-auth-init.sh /home/user/.bashrc.d/00-gh-auth.sh && \
+    chown -R user:user /home/user/.bashrc.d
+
+# Ensure .bashrc sources .bashrc.d scripts
+RUN grep -q '.bashrc.d' /home/user/.bashrc || \
+    echo -e '\n# Source additional shell initialization scripts\nif [ -d ~/.bashrc.d ]; then\n    for rc in ~/.bashrc.d/*; do\n        [ -f "$rc" ] && . "$rc"\n    done\nfi' >> /home/user/.bashrc
+
 # Ensure CLIs are in PATH
 ENV PATH="/home/user/.local/bin:${PATH}"
 

--- a/containers/devspace-base/gh-auth-init.sh
+++ b/containers/devspace-base/gh-auth-init.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# GitHub CLI Auto-Authentication
+# Runs once on first shell initialization to authenticate gh CLI
+# Uses git credential helper to extract GitHub token
+
+# Marker file to track authentication completion
+GH_AUTH_MARKER="$HOME/.config/gh/.auth-initialized"
+
+# Function to authenticate gh CLI
+authenticate_gh() {
+    # Check if gh is already authenticated
+    if gh auth status >/dev/null 2>&1; then
+        touch "$GH_AUTH_MARKER"
+        return 0
+    fi
+
+    # Extract GitHub token from git credential helper
+    GITHUB_TOKEN=$(printf "protocol=https\nhost=github.com\n\n" | git credential fill 2>/dev/null | grep "^password=" | cut -d= -f2)
+
+    if [ -n "$GITHUB_TOKEN" ]; then
+        # Authenticate gh CLI
+        if echo "$GITHUB_TOKEN" | gh auth login --with-token 2>/dev/null; then
+            touch "$GH_AUTH_MARKER"
+            unset GITHUB_TOKEN
+            return 0
+        fi
+    fi
+
+    # Clear token from memory
+    unset GITHUB_TOKEN
+    return 1
+}
+
+# Only run if marker doesn't exist and gh is installed
+if [ ! -f "$GH_AUTH_MARKER" ] && command -v gh >/dev/null 2>&1; then
+    # Run authentication in background to avoid blocking shell startup
+    (
+        # Wait a moment to ensure git credentials are available
+        sleep 1
+        authenticate_gh
+    ) >/dev/null 2>&1 &
+
+    # Disown the background job so it doesn't interfere with shell
+    disown
+fi


### PR DESCRIPTION
## Summary
Adds automatic GitHub CLI authentication to the devspace-base container using shell initialization. This is **Part 1 of 2** for the gh-auth automation feature.

## Changes
- **New**: `containers/devspace-base/gh-auth-init.sh` - Background authentication script
- **Modified**: `containers/devspace-base/Containerfile` - Install gh-auth script for 'user' account

## How It Works
1. gh-auth-init.sh installed at `/usr/local/bin/gh-auth-init.sh`
2. Script symlinked to `~/.bashrc.d/00-gh-auth.sh`
3. `.bashrc` configured to source all scripts in `.bashrc.d/`
4. On first shell startup:
   - Check if gh is already authenticated
   - Extract GitHub token from git credential helper
   - Authenticate gh CLI in background (1s delay, non-blocking)
   - Create marker file to prevent re-runs

## Benefits
- ✅ Automatic authentication on first shell
- ✅ Non-blocking (background job with disown)
- ✅ Idempotent (marker file + auth status check)
- ✅ No postCreate hook required
- ✅ Works in DevSpaces and local DevContainer

## Test Plan
- [ ] Build devspace-base: `podman build -t devspace-base:test containers/devspace-base/`
- [ ] Run container: `podman run -it devspace-base:test bash`
- [ ] Wait 2 seconds after shell starts
- [ ] Verify: `gh auth status` shows authenticated
- [ ] Exit and re-enter shell
- [ ] Verify: No duplicate authentication attempts
- [ ] Check: Only one background process created

## Part 2 (Next PR)
After this PR merges and builds:
- Get the new SHA tag from GHCR
- Update devspace-homelab to extend from new devspace-base
- Add symlink for morey-tech user
- Remove manual gh auth from postCreate.sh

## Related
- #132 - Container build dependency issue (explains why this is split into 2 PRs)
- #131 - Closed (combined PR that had dependency issue)