### PR TITLE
fix(devspaces): correct Roo Code contextWindow to match vLLM max_model_len

### DIFF
--- a/kubernetes/ocp-gpu/system/openshift-devspaces/roo-code-settings-template.yaml
+++ b/kubernetes/ocp-gpu/system/openshift-devspaces/roo-code-settings-template.yaml
@@ -30,8 +30,8 @@ data:
             "openAiApiKey": "xxx",
             "openAiModelId": "local-llm",
             "openAiCustomModelInfo": {
-              "maxTokens": -1,
-              "contextWindow": 40000,
+              "maxTokens": 24576,
+              "contextWindow": 40960,
               "supportsImages": true,
               "supportsPromptCache": false,
               "inputPrice": 0,


### PR DESCRIPTION
## Summary

Fixes a configuration mismatch between the Roo Code vLLM profile and the actual inference server settings.

**Changes**:
- Update `contextWindow` from 40000 to 40960 to match `MAX_MODEL_LEN_START`
- Update `maxTokens` from -1 (automatic) to 24576 to explicitly reserve space for input

## Configuration Changes

File: `kubernetes/ocp-gpu/system/openshift-devspaces/roo-code-settings-template.yaml`

```diff
  "openAiCustomModelInfo": {
-   "maxTokens": -1,
-   "contextWindow": 40000,
+   "maxTokens": 24576,
+   "contextWindow": 40960,
    "supportsImages": true,
```

## Rationale

### contextWindow: 40960
- Matches the vLLM inference server `MAX_MODEL_LEN_START: "40960"` exactly
- Aligns with the model's configured `max_model_length` of 40960
- Ensures Roo Code utilizes the full available context window

### maxTokens: 24576
- Allocates 60% (24576 tokens) for output generation
- Reserves 40% (~16384 tokens) for input context:
  - System prompts (~2000 tokens)
  - Codebase context (5000-15000 tokens)
  - User messages (500-2000 tokens)
- Prevents context overflow errors when working with large codebases

## Model Reference

**Model**: [RedHatAI/Qwen3-30B-A3B-quantized.w4a16](https://huggingface.co/RedHatAI/Qwen3-30B-A3B-quantized.w4a16)
- Base context: 32,768 tokens
- Extended context: 131,072 tokens (with YaRN)
- Configured: 40,960 tokens

## Testing

After merging:
1. Apply the updated ConfigMap to `openshift-devspaces` namespace
2. Restart active Dev Spaces workspaces
3. Verify full context window is available and no overflow errors occur

Closes #153