### PR TITLE
fix(devspaces): install locale to resolve 'cannot change locale' warning

### DIFF
--- a/containers/devspace-homelab/Containerfile
+++ b/containers/devspace-homelab/Containerfile
@@ -13,6 +13,15 @@ ARG TARGETARCH
 
 USER root
 
+# Install and configure locale to prevent "cannot change locale" warnings
+RUN dnf install -y glibc-locale-source glibc-langpack-en \
+    && localedef -i en_US -f UTF-8 en_US.UTF-8 \
+    && dnf clean all
+
+# Set locale environment variables
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
 # Rename 'user' to 'morey-tech' and relocate home directory
 # This maintains compatibility with local devcontainer config while working with DevSpaces
 RUN usermod -l morey-tech user \


### PR DESCRIPTION
## Problem
Roo Code in DevSpaces shows warning:
```
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```

## Solution
- Install `glibc-locale-source` and `glibc-langpack-en` packages in the devspace-homelab container
- Generate the `en_US.UTF-8` locale using `localedef`
- Set `LANG` and `LC_ALL` environment variables to `en_US.UTF-8`

## Technical Details
The warning occurred because the base container image did not have the en_US.UTF-8 locale installed or configured. This is now resolved by:
1. Installing the necessary locale packages via dnf
2. Generating the locale definition
3. Setting environment variables system-wide in the Containerfile

## Testing Required
- Rebuild the devspace-homelab container image
- Start a new DevSpaces workspace
- Verify the locale warning no longer appears

Closes #141