### PR TITLE
feat(ocp-gpu): add docling-serve document processing application

### DIFF
--- a/kubernetes/ocp-gpu/applications/docling-serve/deployment.yaml
+++ b/kubernetes/ocp-gpu/applications/docling-serve/deployment.yaml
@@ -1,0 +1,77 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: docling-serve
+  labels:
+    app: docling-serve
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: docling-serve
+  template:
+    metadata:
+      labels:
+        app: docling-serve
+    spec:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 120
+      containers:
+        - resources:
+            limits:
+              memory: 8Gi
+            requests:
+              cpu: '1'
+              memory: 2Gi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            timeoutSeconds: 5
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          name: server
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            timeoutSeconds: 8
+            periodSeconds: 100
+            successThreshold: 1
+            failureThreshold: 3
+          env:
+            - name: DOCLING_SERVE_ENABLE_UI
+              value: 'true'
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: http
+              containerPort: 5001
+              protocol: TCP
+          imagePullPolicy: IfNotPresent
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            timeoutSeconds: 1
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 24
+          terminationMessagePolicy: File
+          image: 'quay.io/docling-project/docling-serve-cpu:v1.16.1'
+      dnsPolicy: ClusterFirst
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/kubernetes/ocp-gpu/applications/docling-serve/kustomization.yaml
+++ b/kubernetes/ocp-gpu/applications/docling-serve/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  component: docling-serve
+
+resources:
+- deployment.yaml
+- service.yaml
+- route.yaml

--- a/kubernetes/ocp-gpu/applications/docling-serve/route.yaml
+++ b/kubernetes/ocp-gpu/applications/docling-serve/route.yaml
@@ -1,0 +1,18 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: docling-serve
+  labels:
+    app: docling-serve
+  annotations:
+    haproxy.router.openshift.io/timeout: 10m
+spec:
+  to:
+    kind: Service
+    name: docling-serve
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+  wildcardPolicy: None

--- a/kubernetes/ocp-gpu/applications/docling-serve/service.yaml
+++ b/kubernetes/ocp-gpu/applications/docling-serve/service.yaml
@@ -1,0 +1,19 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: docling-serve
+  labels:
+    app: docling-serve
+spec:
+  ipFamilies:
+    - IPv4
+  ports:
+    - name: http
+      protocol: TCP
+      port: 5001
+      targetPort: http
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  sessionAffinity: None
+  selector:
+    app: docling-serve


### PR DESCRIPTION
## Summary

Deploys [docling-serve](https://github.com/docling-project/docling-serve) as a standalone application on the ocp-gpu cluster, providing a REST API for document processing and conversion (PDF, DOCX → JSON, Markdown).

## Changes

New application directory `kubernetes/ocp-gpu/applications/docling-serve/`:

| File | Purpose |
|------|---------|
| `deployment.yaml` | Deployment using `quay.io/docling-project/docling-serve-cpu:v1.16.1`, port 5001, Recreate strategy |
| `service.yaml` | ClusterIP Service on port 5001 |
| `route.yaml` | OpenShift Route with TLS edge termination and 10m HAProxy timeout |
| `kustomization.yaml` | Kustomize config with `commonLabels.component: docling-serve` |

## Key Details

- **Image**: `quay.io/docling-project/docling-serve-cpu:v1.16.1`
- **Port**: 5001 (named `http`)
- **Resources**: requests cpu=1/memory=2Gi, limits memory=8Gi
- **UI**: Enabled via `DOCLING_SERVE_ENABLE_UI=true`
- **Health probes**: readiness/liveness/startup on `/health`
- **Security context**: `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, `seccompProfile.type: RuntimeDefault`, `capabilities.drop: [ALL]`
- **App discovery**: Automatically picked up by `applications-appset` scanning `kubernetes/ocp-gpu/applications/*`

## References

- Upstream deploy example: https://github.com/docling-project/docling-serve/blob/main/docs/deploy-examples/docling-serve-simple.yaml

Closes #182